### PR TITLE
Performance improvement in channel processing

### DIFF
--- a/src/Channel/getChannel.jl
+++ b/src/Channel/getChannel.jl
@@ -312,16 +312,10 @@ function getChannel(nbSamples::Int,channelModel::ChannelModel,randSeed=-1)
 			freq	  = channelModel.samplingFreq;
 			# --- Ensuring additional delay for proper interpolation
 			delay	  = channelModel.delayProfile .+ fdGap;
-			cir		  = zeros(Complex{Float64}, nbSamples, delaySpread + sS);
-			for indexTime = 1 : 1: nbSamples
-				for k = 1 : 1 : delaySpread + sS
-					# --- Each index is superimposition of all timed compondent
-					for ∂ = 1 : 1 : nbTaps
-						# --- Shannon interpolation with sinc. on sincSupport
-						cir[indexTime,k] += powerLin[∂] * raylAmpl[indexTime,∂] * sinc.(pi*(k/freq - delay[∂]) * freq);
-					end
-				end
-			end
+            # --- Shannon interpolation with sinc. on sincSupport
+            shannonInterp = sinc.(pi.*(transpose(1:delaySpread+sS)./freq .- delay) .* freq);
+            # --- Each index is superimposition of all timed compondent
+            cir = transpose(powerLin) .* raylAmpl * shannonInterp;
 			return ChannelImpl(1,cir,channelModel,powerLin,randSeed);
 		else
 			# ----------------------------------------------------

--- a/src/Channel/getChannel.jl
+++ b/src/Channel/getChannel.jl
@@ -315,7 +315,7 @@ function getChannel(nbSamples::Int,channelModel::ChannelModel,randSeed=-1)
             # --- Shannon interpolation with sinc. on sincSupport
             shannonInterp = sinc.(pi.*(transpose(1:delaySpread+sS)./freq .- delay) .* freq);
             # --- Each index is superimposition of all timed compondent
-            cir = transpose(powerLin) .* raylAmpl * shannonInterp;
+            cir = transpose(powerLin) .* raylAmpl[1:nbSamples] * shannonInterp;
 			return ChannelImpl(1,cir,channelModel,powerLin,randSeed);
 		else
 			# ----------------------------------------------------


### PR DESCRIPTION
This PR improves the performance of the channel processing.
It made faster by **270x** in the function `getChannel` and **23x** in the function `applyChannel` than the current version on my computer.

The main changes:
- `getChannel`: generate CIR by matrix operation without for-loop.
- `applyChannel` : process the time-varying convolution in different functions in order to get optimization of the for-loop by the Julia compiler.

p.s. thank you very much for creating this wonderful package!!