### PR TITLE
Performance improvement in the channel generation

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -68,6 +68,7 @@ uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.20.0"
 
 [[LibGit2]]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [[Libdl]]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.0.3"
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/DigitalComm.jl
+++ b/src/DigitalComm.jl
@@ -13,6 +13,7 @@ module DigitalComm
 using FFTW 
 using Statistics
 using DSP
+using LinearAlgebra
 
 # ---------------------------------------------------- 
 # --- Submodules inclusion  


### PR DESCRIPTION
The channel generation functions were still heavier than waveforming and other signal processing.

This PR improves the performance of function `getChannel` by approx. 30%, and adds a new function, namely `renewChannel`, which re-generates only the coefficient of the Rayleigh amplitude in the struct `ChannelImpl` to be faster than re-running `getChannel`.  The function `renewChannel` is approx. 50% faster than the original version of `getChannel`.

The main changes:

- `getChannel`: store path gains in power with interpolation (`powerLinInterp`) into `ChannelImpl` to re-use this in the function `renewChannel`.
- `applyChannel`: add an in-place function `applyChannel!`.
- `renewChannel!`: re-generate Rayleigh amplitude `raylAmpl` using the package `LinearAlgebra`. 
- `rayleighChan`: add an in-place function `rayleighChan!`, and optimize the calculation.

Thanks.