### PR TITLE
Expand DSP.jl compat bounds to support v0.7 to v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DigitalComm"
 uuid = "a7b11256-881b-11e9-3aff-ff4a76f1bfae"
 authors = ["Robin Gerzaguet <robin.gerzaguet@irisa.fr> and contributors"]
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Parameters = "0.12"
-DSP = "0.7"
+DSP = ">=0.7, <0.9"
 FFTW = "1.4.5"
 SpecialFunctions = "2.0"
 julia = "1.6"


### PR DESCRIPTION
### What  
- - Updates `[compat]` entry for `DSP.jl` in `Project.toml` to allow versions `≥0.7` and `≤0.8`.  
- Ensures compatibility with both legacy and newer DSP.jl releases.  

### Why  
- Required to integrate with other package which depends on DSP.jl `v0.8+`.  

### Testing  
-  Local tests run successfully.  